### PR TITLE
add gesvd implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub use vector::Vector;
 pub use types::*;
 pub use eigenvalues::*;
 pub use general_eigenvalues::*;
+pub use svd::*;
 pub use least_squares::*;
 pub use linear_equations::*;
 
@@ -31,3 +32,4 @@ pub mod linear_equations;
 pub mod least_squares;
 pub mod eigenvalues;
 pub mod general_eigenvalues;
+pub mod svd;

--- a/src/svd.rs
+++ b/src/svd.rs
@@ -1,0 +1,136 @@
+use std::mem;
+use std::ptr;
+use libc::c_int;
+use error::Error;
+use ll::*;
+use Matrix;
+use Vector;
+use scalar::Scalar;
+use types::Compute;
+use util::ColMem;
+
+pub trait Gesvd<Eigenvalues>: Sized {
+    fn gesvd(a: &mut Matrix<Self>, left: Option<&mut Matrix<Self>>, right: Option<&mut Matrix<Self>>) -> Result<Vec<Eigenvalues>, Error> {
+
+        let job_l = match &left {
+            &Some(_) => Compute::Some,
+            _ => Compute::None,
+        };
+
+        let job_r = match &right {
+            &Some(_) => Compute::Some,
+            _ => Compute::None,
+        };
+
+        let work_len = try!(Gesvd::work_len(a, job_l, job_r));
+        let mut work: Vec<_> = Vec::with_capacity(work_len as usize);
+        unsafe {
+            work.set_len(work_len as usize);
+        }
+
+        Gesvd::work(a, left, right, &mut work[..])
+    }
+    fn work(a: &mut Matrix<Self>,
+        left: Option<&mut Matrix<Self>>, right: Option<&mut Matrix<Self>>, work: &mut [Self]) -> Result<Vec<Eigenvalues>, Error>;
+    fn work_len(a: &mut Matrix<Self>, left: Compute, right: Compute) -> Result<usize, Error>;
+}
+
+macro_rules! real_svd_impl(($($t: ident), +) => ($(
+    impl Gesvd<$t> for $t {
+        fn work(a: &mut Matrix<Self>, left: Option<&mut Matrix<Self>>, right: Option<&mut Matrix<Self>>, work: &mut [Self]) -> Result<Vec<$t>, Error> {
+
+            let mut info: c_int = 0;
+            let m = a.rows();
+            let n = a.cols();
+
+            if m < n {
+                return Err(Error::DimensionMismatch);
+            }
+
+            let mut a_mem = ColMem::new(a.order(), a);
+
+            let (job_l, lead_l, ptr_l) = match left {
+                Some(m) => (Compute::Some, m.rows(), m.as_mut_ptr()),
+                None => (Compute::None, 1, ptr::null::<$t>() as *mut _),
+            };
+
+            let (job_r, lead_r, ptr_r) = match right {
+                Some(m) => (Compute::Some, m.rows(), m.as_mut_ptr()),
+                None => (Compute::None, 1, ptr::null::<$t>() as *mut _),
+            };
+
+            let mut singular_values: Vec<_> = Vec::with_capacity(n as usize);
+
+            unsafe {
+                singular_values.set_len(n as usize);
+
+                prefix!($t, gesvd_)(
+                    job_l.as_i8().as_mut(), job_r.as_i8().as_mut(),
+                    m.as_mut(), n.as_mut(),
+                    a_mem.as_mut_ptr(),
+                    a_mem.lead().as_mut(),
+                    singular_values.as_mut_ptr(),
+                    ptr_l, lead_l.as_mut(),
+                    ptr_r, lead_r.as_mut(),
+                    work.as_mut_ptr(), (work.len() as c_int).as_mut(),
+                    &mut info as *mut c_int);
+            };
+
+            match info {
+                0 => Ok(singular_values),
+                x if x < 0 => Err(Error::IllegalParameter(-x as usize)),
+                x => Err(Error::DiagonalElementZero(x as usize)),
+            }
+        }
+
+        fn work_len(a: &mut Matrix<Self>, left: Compute, right: Compute) -> Result<usize, Error> {
+            let mut info: c_int = 0;
+            let mut len_info: $t = unsafe { mem::zeroed() };
+            let len_ptr = (&mut len_info) as *mut $t;
+
+            let m = a.rows();
+            let n = a.cols();
+            let lda = m;
+
+            unsafe {
+                prefix!($t, gesvd_)(
+                    left.as_i8().as_mut(), right.as_i8().as_mut(),
+                    m.as_mut(), n.as_mut(),
+                    a.as_mut_ptr(), lda.as_mut(),
+                    ptr::null::<$t>() as *mut _, // S
+                    ptr::null::<$t>() as *mut _, // U
+                    m.as_mut(),                  // LDU
+                    ptr::null::<$t>() as *mut _, // VT
+                    n.as_mut(),                  // LDVT
+                    len_ptr, (-1 as c_int).as_mut(),
+                    &mut info as *mut c_int);
+            };
+
+            match info {
+                0 => Ok(len_info.as_work()),
+                x if x < 0 => Err(Error::IllegalParameter(-x as usize)),
+                x => Err(Error::DiagonalElementZero(x as usize)),
+            }
+        }
+    }
+)+));
+
+real_svd_impl!(f32, f64);
+
+#[cfg(test)]
+mod gesvd_tests {
+    use svd::Gesvd;
+    use matrix::tests::M;
+    use types::Order::*;
+
+    #[test]
+    fn real() {
+        let mut a = M(RowMajor, 3i32, 2i32, vec![3.0f32, 2.0, 2.0, 3.0, 2.0, -2.0]);
+        let mut v = M(RowMajor, 2i32, 2i32, vec![0.0, 0.0, 0.0, 0.0]);
+        let lambda = Gesvd::gesvd(&mut a, None, Some(&mut v)).unwrap();
+
+        assert!((lambda[0] - 5.0).abs() < 0.0000001);
+        assert!((lambda[1] - 3.0).abs() < 0.001);
+        assert_eq!(v.3[0], 0.0);
+    }
+}

--- a/src/svd.rs
+++ b/src/svd.rs
@@ -13,12 +13,12 @@ pub trait Gesvd<Eigenvalues>: Sized {
     fn gesvd(a: &mut Matrix<Self>, left: Option<&mut Matrix<Self>>, right: Option<&mut Matrix<Self>>) -> Result<Vec<Eigenvalues>, Error> {
 
         let job_l = match &left {
-            &Some(_) => Compute::Some,
+            &Some(_) => Compute::All,
             _ => Compute::None,
         };
 
         let job_r = match &right {
-            &Some(_) => Compute::Some,
+            &Some(_) => Compute::All,
             _ => Compute::None,
         };
 
@@ -43,19 +43,15 @@ macro_rules! real_svd_impl(($($t: ident), +) => ($(
             let m = a.rows();
             let n = a.cols();
 
-            if m < n {
-                return Err(Error::DimensionMismatch);
-            }
-
             let mut a_mem = ColMem::new(a.order(), a);
 
             let (job_l, lead_l, ptr_l) = match left {
-                Some(m) => (Compute::Some, m.rows(), m.as_mut_ptr()),
+                Some(m) => (Compute::All, m.rows(), m.as_mut_ptr()),
                 None => (Compute::None, 1, ptr::null::<$t>() as *mut _),
             };
 
             let (job_r, lead_r, ptr_r) = match right {
-                Some(m) => (Compute::Some, m.rows(), m.as_mut_ptr()),
+                Some(m) => (Compute::All, m.rows(), m.as_mut_ptr()),
                 None => (Compute::None, 1, ptr::null::<$t>() as *mut _),
             };
 

--- a/src/svd.rs
+++ b/src/svd.rs
@@ -129,8 +129,7 @@ mod gesvd_tests {
         let mut v = M(RowMajor, 2i32, 2i32, vec![0.0, 0.0, 0.0, 0.0]);
         let lambda = Gesvd::gesvd(&mut a, None, Some(&mut v)).unwrap();
 
-        assert!((lambda[0] - 5.0).abs() < 0.0000001);
-        assert!((lambda[1] - 3.0).abs() < 0.001);
-        assert_eq!(v.3[0], 0.0);
+        assert!((lambda[0] - 5.0).abs() < 0.00001);
+        assert!((lambda[1] - 3.0).abs() < 0.00001);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,8 +16,8 @@ pub enum Compute {
     None,
     Value,
     All,
-    Some,
-    OverwriteSome,
+    Partial,
+    OverwritePartial,
 }
 
 impl Compute {

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,13 +15,19 @@ pub enum Order {
 pub enum Compute {
     None,
     Value,
+    All,
+    Some,
+    OverwriteSome,
 }
 
 impl Compute {
     pub fn as_i8(self) -> i8 {
         match self {
-            Compute::None => 78,
-            Compute::Value => 86,
+            Compute::None => 'N' as i8,
+            Compute::Value => 'V' as i8,
+            Compute::All => 'A' as i8,
+            Compute::Some => 'S' as i8,
+            Compute::OverwriteSome => 'O' as i8
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -26,8 +26,8 @@ impl Compute {
             Compute::None => 'N' as i8,
             Compute::Value => 'V' as i8,
             Compute::All => 'A' as i8,
-            Compute::Some => 'S' as i8,
-            Compute::OverwriteSome => 'O' as i8
+            Compute::Partial => 'S' as i8,
+            Compute::OverwritePartial => 'O' as i8
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,6 +8,8 @@ use matrix::Matrix;
 use types::Order;
 use types::Order::*;
 
+/// ColMem is a utility structure for temporarily representing data
+/// from another matrix as in column-major format.
 pub struct ColMem<'a, T: 'a> {
     source: &'a mut Matrix<T>,
     lead: i32,
@@ -46,8 +48,10 @@ impl<'a, T> ColMem<'a, T> {
         }
     }
 
+    /// Return the leading storage dimension of the matrix.
     pub fn lead(&self) -> i32 { self.lead }
 
+    /// Return a mutable pointer to the data.
     pub fn as_mut_ptr(&mut self) -> *mut T {
         match self.data {
             Some(ref mut v) => v.as_mut_ptr(),


### PR DESCRIPTION
I added a wrapper for the *gesvd family of functions for computing singular value decompositions.

The *gesdd family is supposed to be faster and use less memory in most cases, but I haven't yet added it. It would probably makes sense to have generic svd function which chooses the best function based on the size of the parameters, but I haven't done enough testing to know what the conditions for using one or the other should be.
